### PR TITLE
Fix deprecated privilege escalation

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: Swap for Ubuntu 14.04
   company: Novuso
   license: license (MIT)
-  min_ansible_version: 1.6
+  min_ansible_version: 1.9
   platforms:
   - name: Ubuntu
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: "swap space"
-  sudo: yes
+  become: yes
   command: |
     {% if swap_use_dd %}
     dd if=/dev/zero of={{ swap_file }} bs=1M count={{ swap_size }}
@@ -13,7 +13,7 @@
   when: swap_size != false
 
 - name: "swap permissions"
-  sudo: yes
+  become: yes
   file:
     dest: "{{ swap_file }}"
     owner: "root"
@@ -22,18 +22,18 @@
   when: swap_size != false
 
 - name: "make swap"
-  sudo: yes
+  become: yes
   command: "mkswap {{ swap_file }}"
   register: swap_make
   when: swap_size != false and swap_write.changed
 
 - name: "enable swap"
-  sudo: yes
+  become: yes
   command: "swapon {{ swap_file }}"
   when: swap_size != false and swap_make.changed
 
 - name: "swap fstab"
-  sudo: yes
+  become: yes
   lineinfile:
     dest: "/etc/fstab"
     line: "{{ swap_file }}   none    swap   sw    0   0"
@@ -41,7 +41,7 @@
   when: swap_size != false
 
 - name: "swappiness"
-  sudo: yes
+  become: yes
   sysctl:
     name: "vm.swappiness"
     value: "{{ swap_swappiness }}"
@@ -50,7 +50,7 @@
   when: swap_swappiness != false
 
 - name: "vfs cache pressure"
-  sudo: yes
+  become: yes
   sysctl:
     name: "vm.vfs_cache_pressure"
     value: "{{ swap_vfs_cache_pressure }}"


### PR DESCRIPTION
Ansible 1.9 deprecates `sudo` in favor of `become`.  I'm running version `2.0.1.0` and receive this warning:

```
[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and make sure become_method is 'sudo' (default). This feature will be removed in a future release. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

This fixes the deprecation warning and sets the minimum Ansible version to `1.9`.  
